### PR TITLE
Use cp1252 instead of utf8 for encoding of file names on Python 3

### DIFF
--- a/mahotas/io/freeimage.py
+++ b/mahotas/io/freeimage.py
@@ -700,6 +700,10 @@ def imsave(filename, img):
 
 
 if sys.version_info[0] > 2:
-    _bytestr = lambda x: x.encode('cp1252')
+    import locale
+    _, _encoding = locale.getdefaultlocale()
+    if _encoding is None:
+        _encoding = 'UTF-8'
+    _bytestr = lambda x: x.encode(_encoding)
 else:
     _bytestr = str


### PR DESCRIPTION
This will allow for some non ASCII7 characters in file names
