### PR TITLE
Fix mahotas.tests.test_convolve.test_compare_w_ndimage error on Windows

### DIFF
--- a/mahotas/tests/test_convolve.py
+++ b/mahotas/tests/test_convolve.py
@@ -8,7 +8,7 @@ from nose.tools import raises
 
 def test_compare_w_ndimage():
     from scipy import ndimage
-    A = np.arange(34*340).reshape((34,340))%3
+    A = np.arange(34*340, dtype='float64').reshape((34,340))%3
     B = np.ones((3,3), A.dtype)
     for mode in mahotas._filters.modes:
         assert np.all(mahotas.convolve(A, B, mode=mode) == ndimage.convolve(A, B, mode=mode))


### PR DESCRIPTION
On Windows with numpy 1.6.2 and scipy 0.11.0rc2, the following test fails:

```
ERROR: mahotas.tests.test_convolve.test_compare_w_ndimage
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "X:\Python27\lib\site-packages\mahotas\tests\test_convolve.py", line 16, in test_compare_w_ndimage
    assert np.all(mahotas.convolve(A, B, mode=mode) == ndimage.convolve(A, B, mode=mode))
  File "X:\Python27\lib\site-packages\scipy\ndimage\filters.py", line 664, in convolve
    origin, True)
  File "X:\Python27\lib\site-packages\scipy\ndimage\filters.py", line 512, in _correlate_or_convolve
    _nd_image.correlate(input, weights, output, mode, cval, origins)
RuntimeError: array type not supported
```

This is a bug in numpy or ndimage, but the mahotas test error can easily be avoided by using a float type for the test array.

I tracked this down to the fact that `np.arange(1).dtype.type != (np.arange(1)%2).dtype.type`, at least on my system.
