### PR TITLE
Fix build failure with msvc

### DIFF
--- a/mahotas/numpypp/numpy.hpp
+++ b/mahotas/numpypp/numpy.hpp
@@ -31,6 +31,10 @@ npy_intp dtype_code<int>() { return NPY_INT; }
 
 template <>
 inline
+npy_intp dtype_code<long>() { return NPY_LONG; }
+
+template <>
+inline
 npy_intp dtype_code<double>() { return NPY_DOUBLE; }
 
 template<typename T>


### PR DESCRIPTION
This fixes a link error when building with msvc9 on Windows:

```
_center_of_mass.obj : error LNK2019: unresolved external symbol "int __cdecl numpy::dtype_code<long>(void)" (??$dtype_code@J@numpy@@YAHXZ) referenced in function "bool __cdecl numpy::check_type<long>(struct PyArrayObject *)" (??$check_type@J@numpy@@YA_NPAUPyArrayObject@@@Z)
```
