### PR TITLE
Make mode an optional parameter in function for getting borders and perimeter

### DIFF
--- a/mahotas/_labeled.cpp
+++ b/mahotas/_labeled.cpp
@@ -87,11 +87,11 @@ int label(numpy::aligned_array<int> labeled, numpy::aligned_array<int> Bc) {
 
 
 template<typename T>
-void borders(numpy::aligned_array<T> array, numpy::aligned_array<T> filter, numpy::aligned_array<bool> result) {
+void borders(numpy::aligned_array<T> array, numpy::aligned_array<T> filter, numpy::aligned_array<bool> result, int mode) {
     gil_release nogil;
     const int N = array.size();
     typename numpy::aligned_array<T>::iterator iter = array.begin();
-    filter_iterator<T> fiter(array.raw_array(), filter.raw_array(), EXTEND_CONSTANT, true);
+    filter_iterator<T> fiter(array.raw_array(), filter.raw_array(), ExtendMode(mode), true);
     const int N2 = fiter.size();
     bool* out = result.data();
 
@@ -202,7 +202,8 @@ PyObject* py_borders(PyObject* self, PyObject* args) {
     PyArrayObject* array;
     PyArrayObject* filter;
     PyArrayObject* output;
-    if (!PyArg_ParseTuple(args,"OOO", &array, &filter, &output)) return NULL;
+    int mode;
+    if (!PyArg_ParseTuple(args,"OOOi", &array, &filter, &output, &mode)) return NULL;
     if (!numpy::are_arrays(array, filter, output) ||
         !numpy::equiv_typenums(array, filter) ||
         !numpy::check_type<bool>(output) ||
@@ -217,7 +218,8 @@ PyObject* py_borders(PyObject* self, PyObject* args) {
     borders<type>( \
                 numpy::aligned_array<type>(array), \
                 numpy::aligned_array<type>(filter), \
-                numpy::aligned_array<bool>(output));
+                numpy::aligned_array<bool>(output), \
+                mode);
     SAFE_SWITCH_ON_TYPES_OF(array, false)
 #undef HANDLE
     if (PyErr_Occurred()) {

--- a/mahotas/labeled.py
+++ b/mahotas/labeled.py
@@ -8,6 +8,7 @@ import numpy as np
 from .morph import get_structuring_elem
 from . import _labeled
 from .internal import _get_output
+from ._filters import mode2int, modes, _check_mode
 
 __all__ = [
     'borders',
@@ -134,7 +135,7 @@ def border(labeled, i, j, Bc=None, out=None, always_return=True, output=None):
     output.fill(False)
     return _labeled.border(labeled, Bc, output, i, j, bool(always_return))
 
-def borders(labeled, Bc=None, out=None, output=None):
+def borders(labeled, Bc=None, out=None, output=None, mode='constant'):
     '''
     border_img = borders(labeled, Bc={3x3 cross}, out={np.zeros(labeled.shape, bool)})
 
@@ -150,6 +151,8 @@ def borders(labeled, Bc=None, out=None, output=None):
     Bc : structure element, optional
     out : ndarray of same shape as `labeled`, dtype=bool, optional
         where to store the output. If ``None``, a new array is allocated
+    mode : {'reflect', 'nearest', 'wrap', 'mirror', 'constant' [default]}
+        How to handle borders
 
     Returns
     -------
@@ -159,9 +162,9 @@ def borders(labeled, Bc=None, out=None, output=None):
     Bc = get_structuring_elem(labeled, Bc)
     output = _get_output(labeled, out, 'labeled.borders', bool, output=output)
     output.fill(False)
-    return _labeled.borders(labeled, Bc, output)
+    return _labeled.borders(labeled, Bc, output, mode2int[mode])
 
-def bwperim(bw, n=4):
+def bwperim(bw, n=4, mode="constant"):
     '''
     perim = bwperim(bw, n=4)
 
@@ -179,6 +182,8 @@ def bwperim(bw, n=4):
         A black-and-white image (any other image will be converted to black & white)
     n : int, optional
         Connectivity. Must be 4 or 8 (default: 4)
+    mode : {'reflect', 'nearest', 'wrap', 'mirror', 'constant' [default]}
+        How to handle borders
 
     Returns
     -------
@@ -191,7 +196,7 @@ def bwperim(bw, n=4):
         This is a more generic function
     '''
     bw = (bw != 0)
-    return bw&borders(bw, n)
+    return bw&borders(bw, n, mode=mode)
 
 def _check_array_labeled(array, labeled, funcname):
     if labeled.dtype != np.intc or not labeled.flags.carray:


### PR DESCRIPTION
This is similar to #22, but concerns bwperim, which I would like to evaluate with periodic boundary conditions. However, the filter used in _labeled.borders had 'constant' mode hardcoded in it, so I had to change that extension. I don't think this influences any other code, at least the tests look fine.

I must say, it's fun working with mahotas.
