### PR TITLE
Update moments.py

### DIFF
--- a/mahotas/features/moments.py
+++ b/mahotas/features/moments.py
@@ -57,14 +57,14 @@ def moments(img, p0, p1, cm=None, convert_to_float=True, normalize=False, normal
     r,c = img.shape
     p = np.arange(c, dtype=float)
     if cm is not None:
-        p -= cm[1]
+        p -= cm[0]
     p **= p0
     if normalize:
         p /= p.sum()
     inter = np.dot(img, p)
     p = np.arange(r, dtype=float)
     if cm is not None:
-        p -= cm[0]
+        p -= cm[1]
     p **= p1
     if normalize:
         p /= p.sum()


### PR DESCRIPTION
When its first order and you are trying to calculate central moments:

\sum_{ij} { img[i,j] (i - c0)**p0 } = dot(img, (p - cm[0])  ** p0)

not p1 as stated in code (I'm still very new to Image Processing so I may be mistaken) 

As proposed, I was able to get First order central moments to be near zero while I wasn't able to do so the way you have it. I can send you the snippet of code i isolated and some sample image runs and their results if you want.