### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ You can test your installation by running:
 
 If you run into issues, the manual has more [extensive documentation on
 mahotas
-installation](http://mahotas.readthedocs.org/en/latest/install.html),
+installation](https://mahotas.readthedocs.io/en/latest/install.html),
 including how to find pre-built for several platforms.
 
 ## Citation
@@ -187,7 +187,7 @@ run the test suite.
 ## Links & Contacts
 
 *Documentation*:
-[http://mahotas.readthedocs.org/](http://mahotas.readthedocs.org/)
+[https://mahotas.readthedocs.io/](https://mahotas.readthedocs.io/)
 
 *Issue Tracker*: [github mahotas
 issues](https://github.com/luispedro/mahotas/issues)

--- a/docs/source/io.rst
+++ b/docs/source/io.rst
@@ -20,7 +20,7 @@ It can use the following backends (it tries them in the following order):
     Freeimage can read and write many formats. Unfortunately, it is harder to
     install and it is not as well-maintained as imread.
 
-3.  Finally, it tries to load `pillow <https://pillow.readthedocs.org/>`__.
+3.  Finally, it tries to load `pillow <https://pillow.readthedocs.io/>`__.
 
 Thus, to use the ``imread`` or ``imsave`` functions, you need to install one of
 the packages above. At one point, mahotas supported wrapping matplotlib, but

--- a/mahotas/__init__.py
+++ b/mahotas/__init__.py
@@ -19,7 +19,7 @@ watershed
 imread/imsave
     read/write image
 
-Documentation: http://mahotas.readthedocs.org/
+Documentation: https://mahotas.readthedocs.io/
 
 Citation:
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.