### PR TITLE
Fixes shape extraction

### DIFF
--- a/mahotas/features/_texture.cpp
+++ b/mahotas/features/_texture.cpp
@@ -62,7 +62,7 @@ PyObject* py_cooccurent(PyObject* self, PyObject* args) {
     if (symmetric) {
         numpy::aligned_array<npy_int32> cmatrix(result);
         const int s0 = cmatrix.size(0);
-        const int s1 = cmatrix.size(0);
+        const int s1 = cmatrix.size(1);
 
         if (s0 != s1) {
             PyErr_SetString(PyExc_RuntimeError, "mahotas._texture.cooccurence: Results matrix not square.");


### PR DESCRIPTION
s1 is supposed to hold number of columns of array i.e its shape in dimension 1.
The commit fixes the call to cmatrix.size(1)