### PR TITLE
Fix px vector computation

### DIFF
--- a/mahotas/features/texture.py
+++ b/mahotas/features/texture.py
@@ -271,8 +271,8 @@ def haralick_features(cmats,
 
         p = cmat / float(T)
         pravel = p.ravel()
-        px = p.sum(0)
-        py = p.sum(1)
+        px = p.sum(1)
+        py = p.sum(0)
 
         ux = np.dot(px, k)
         uy = np.dot(py, k)


### PR DESCRIPTION
The paper mentions computation of px as 'summing the rows' of cmat (GLCM matrix) i.e sum of values in x (horizontal) direction, which in python corresponds to summation along axis=1;
and py as  sum of column values or sum of values in y (vertical) direction, which in Python corresponds to summation along axis=0.

The computation of px in paper is  
![here](http://www.sciweavers.org/tex2img.php?eq=p_x%28i%29%20%3D%20%5Csum_%7Bj%3D1%7D%5E%7BN_g%7DP%28i%2Cj%29&bc=White&fc=Black&im=jpg&fs=12&ff=arev&edit=0)  
and that of py is as shown below:  
![here](http://www.sciweavers.org/tex2img.php?eq=p_y%28j%29%20%3D%20%5Csum_%7Bi%3D1%7D%5E%7BN_g%7DP%28i%2Cj%29&bc=White&fc=Black&im=jpg&fs=12&ff=arev&edit=0)

