### PR TITLE
DOC fix a few simple typos

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -54,7 +54,7 @@ Packaged Versions
 On Windows
 ~~~~~~~~~~
 
-On Windows, Christoph Gohlke does an excelent job maintaining `binary packages
+On Windows, Christoph Gohlke does an excellent job maintaining `binary packages
 of mahotas <http://www.lfd.uci.edu/~gohlke/pythonlibs/>`__ (and several other
 packages).
 

--- a/mahotas/features/moments.py
+++ b/mahotas/features/moments.py
@@ -20,7 +20,7 @@ def moments(img, p0, p1, cm=None, convert_to_float=True, normalize=False, normal
     where cm = (c0,c1). If `cm` is not given, then (0,0) is used.
 
     If image is of an integer type, then it is internally converted to
-    np.float64, unlesss `convert_to_float` is False. The reason is that,
+    np.float64, unless `convert_to_float` is False. The reason is that,
     otherwise, overflow is likely except for small images. Since this
     conversion takes longer than the computation, you can turn it off in case
     you are sure that your images are small enough for overflow to be an issue.


### PR DESCRIPTION
There are small typos in:
- docs/source/install.rst
- mahotas/features/moments.py

Fixes:
- Should read `unless` rather than `unlesss`.
- Should read `excellent` rather than `excelent`.

Closes #122