### PR TITLE
Add build wheeel on CI using cibuildwheel and modernize metadata

### DIFF
--- a/.github/workflows/test-python-package-with-conda.yml
+++ b/.github/workflows/test-python-package-with-conda.yml
@@ -74,7 +74,7 @@ jobs:
               numpy-version: '1.22'
 
 
-            # NumPy <1.25 are too old for Python 3.12
+            # NumPy <=1.25 are too old for Python 3.12
             - python-version: '3.12'
               numpy-version: '1.19'
             - python-version: '3.12'

--- a/.github/workflows/test-python-package-with-conda.yml
+++ b/.github/workflows/test-python-package-with-conda.yml
@@ -2,6 +2,10 @@ name: Test mahotas
 
 on: [push]
 
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -1,0 +1,63 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  make_sdist:
+    name: Make SDist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Optional, use if you use setuptools_scm
+          submodules: true  # Optional, use if you have submodules
+
+      - name: Build SDist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-sdist
+          path: dist/*.tar.gz
+
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # macos-13 is an intel runner, macos-14 is apple silicon
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.17.0
+        # env:
+        #   CIBW_SOME_OPTION: value
+        #    ...
+        # with:
+        #   package-dir: .
+        #   output-dir: wheelhouse
+        #   config-file: "{package}/pyproject.toml"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl
+
+  upload_all:
+    needs: [ build_wheels, make_sdist ]
+    environment: pypi
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -1,6 +1,18 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - main
+      - master
+      - build_wheel
+  pull_request:
+
+concurrency:
+  group: wheel-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   make_sdist:
@@ -24,6 +36,7 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
         os: [ubuntu-latest, windows-latest, macos-13, macos-14]

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build wheel and sdist
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+wheelhouse
 dist/
 build/
 mahotas.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,5 @@ build-backend = "setuptools.build_meta"
 test-command = "pytest --import-mode=importlib {project}/mahotas/tests"
 test-extras = ["tests"]
 test-skip = ["*manylinux*i686", "pp*", "cp31*-win32"]
-skip= "pp37-macosx*"
+skip= "pp37*"
 environment = { PIP_PREFER_BINARY="1", PIP_VERBOSE="1" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,4 @@ build-backend = "setuptools.build_meta"
 test-command = "pytest --import-mode=importlib {project}/mahotas/tests"
 test-extras = ["tests"]
 skip = "*manylinux*i686"
+environment = { PIP_ONLY_BINARY="numpy scipy" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = [
+    "setuptools",
+    "oldest-supported-numpy ; python_version<'3.12'",
+    "numpy; python_version>='3.12'",
+]
+build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel]
+test-command = "pytest --import-mode=importlib {project}/mahotas/tests"
+test-extras = ["tests"]
+skip = "*manylinux*i686"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,5 +9,5 @@ build-backend = "setuptools.build_meta"
 [tool.cibuildwheel]
 test-command = "pytest --import-mode=importlib {project}/mahotas/tests"
 test-extras = ["tests"]
-test-skip = ["*manylinux*i686", "pp*-macosx_arm64", "pp37*", "cp31*-win32"]
+test-skip = ["*manylinux*i686", "pp*", "cp31*-win32"]
 environment = { PIP_PREFER_BINARY="1", PIP_VERBOSE="1" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,11 @@
 [build-system]
-requires = [
-    "setuptools",
-    "oldest-supported-numpy ; python_version<'3.12'",
-    "numpy; python_version>='3.12'",
-]
+requires = ["setuptools", "numpy"]
+# When build with numpy>=1.25 the resulted binary wheel is compatybile with numpy >=1.16
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 test-command = "pytest --import-mode=importlib {project}/mahotas/tests"
 test-extras = ["tests"]
-test-skip = ["*manylinux*i686", "pp*", "cp31*-win32"]
-skip= ["pp37*", "pp310*", "musllinux"]
+test-skip = ["pp*", "cp31*-win32"]
+skip= ["pp37*", "pp310*", "musllinux", "*manylinux*i686"]
 environment = { PIP_PREFER_BINARY="1", PIP_VERBOSE="1" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,4 +8,4 @@ test-command = "pytest --import-mode=importlib {project}/mahotas/tests"
 test-extras = ["tests"]
 test-skip = ["pp*", "cp31*-win32"]
 skip= ["pp37*", "pp310*", "*musllinux*", "*manylinux*i686"]
-environment = { PIP_PREFER_BINARY="1", PIP_VERBOSE="1" }
+environment = { PIP_PREFER_BINARY="1"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,5 @@ build-backend = "setuptools.build_meta"
 test-command = "pytest --import-mode=importlib {project}/mahotas/tests"
 test-extras = ["tests"]
 test-skip = ["*manylinux*i686", "pp*", "cp31*-win32"]
-skip= "pp37*"
+skip= ["pp37*", "musllinux"]
 environment = { PIP_PREFER_BINARY="1", PIP_VERBOSE="1" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,5 +7,5 @@ build-backend = "setuptools.build_meta"
 test-command = "pytest --import-mode=importlib {project}/mahotas/tests"
 test-extras = ["tests"]
 test-skip = ["pp*", "cp31*-win32"]
-skip= ["pp37*", "pp310*", "musllinux", "*manylinux*i686"]
+skip= ["pp37*", "pp310*", "*musllinux*", "*manylinux*i686"]
 environment = { PIP_PREFER_BINARY="1", PIP_VERBOSE="1" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,5 @@ build-backend = "setuptools.build_meta"
 test-command = "pytest --import-mode=importlib {project}/mahotas/tests"
 test-extras = ["tests"]
 test-skip = ["*manylinux*i686", "pp*", "cp31*-win32"]
-skip= ["pp37*", "musllinux"]
+skip= ["pp37*", "pp310*", "musllinux"]
 environment = { PIP_PREFER_BINARY="1", PIP_VERBOSE="1" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,6 @@ build-backend = "setuptools.build_meta"
 [tool.cibuildwheel]
 test-command = "pytest --import-mode=importlib {project}/mahotas/tests"
 test-extras = ["tests"]
-test-skip = ["pp*", "cp31*-win32"]
-skip= ["pp37*", "pp310*", "*musllinux*", "*manylinux*i686"]
+test-skip = ["pp*", "cp31*-win32"]  # there are no scipy weels for this version
+skip= ["pp37*", "pp310*", "*musllinux*", "*manylinux*i686"] # there are no numpy wheels for this version
 environment = { PIP_PREFER_BINARY="1"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,5 +9,5 @@ build-backend = "setuptools.build_meta"
 [tool.cibuildwheel]
 test-command = "pytest --import-mode=importlib {project}/mahotas/tests"
 test-extras = ["tests"]
-skip = ["*manylinux*i686", "pp38-macosx_arm64", "pp37*"]
+test-skip = ["*manylinux*i686", "pp*-macosx_arm64", "pp37*", "cp31*-win32"]
 environment = { PIP_PREFER_BINARY="1", PIP_VERBOSE="1" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,5 +9,5 @@ build-backend = "setuptools.build_meta"
 [tool.cibuildwheel]
 test-command = "pytest --import-mode=importlib {project}/mahotas/tests"
 test-extras = ["tests"]
-skip = "*manylinux*i686"
-environment = { PIP_ONLY_BINARY="numpy scipy" }
+skip = ["*manylinux*i686", "pp38-macosx_arm64", "pp37*"]
+environment = { PIP_PREFER_BINARY="1", PIP_VERBOSE="1" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,4 +10,5 @@ build-backend = "setuptools.build_meta"
 test-command = "pytest --import-mode=importlib {project}/mahotas/tests"
 test-extras = ["tests"]
 test-skip = ["*manylinux*i686", "pp*", "cp31*-win32"]
+skip= "pp37-macosx*"
 environment = { PIP_PREFER_BINARY="1", PIP_VERBOSE="1" }

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,8 @@ package_data = {
 install_requires = open('requirements.txt').read().strip().split('\n')
 
 tests_require = open('tests-requirements.txt').read().strip().split('\n')
+if "freeimage" in tests_require:
+    tests_require.pop(tests_require.index("freeimage"))
 
 copt={
     'msvc': ['/EHsc'], 
@@ -158,6 +160,9 @@ setuptools.setup(name = 'mahotas',
       },
       install_requires = install_requires,
       tests_require = tests_require,
-      cmdclass = {'build_ext': build_ext_subclass}
+      cmdclass = {'build_ext': build_ext_subclass},
+      extras_require = {
+        "tests": tests_require,
+        },
       )
 


### PR DESCRIPTION
In this PR I have added `pyproject.toml` with information about required packages bu build wheel (section `build-system`). This will alow to install `mahotas` with `pip install mahotas` even when wheels are not available. 

This PR also adds [cibuildwheel](https://github.com/pypa/cibuildwheel/) with proper workflow and configuration. 

I have decided to not build wheels for `musllinux`, pypy in version 3.7 and 3.10 and 32-bits `manylinux` because of lack of `numpy` wheels. 

I also need to disable testing on 32-bits windows and pypy because of lack of scipy wheels (it may be possible to fix this, but it will drastically increase build time). 

I have also added steep for automatically upload wheels for PyPI. It will require additional configuration described here: https://docs.pypi.org/trusted-publishers/adding-a-publisher/ 

I have modified test_extras to remove `freeimage` from it, as it does not exist on pypi. 

Suppress #139
