### PR TITLE
Fix build wheel by enforce using pytest 8.11

### DIFF
--- a/tests-requirements.txt
+++ b/tests-requirements.txt
@@ -2,6 +2,6 @@ matplotlib
 pip
 freeimage
 coveralls
-pytest
+pytest==8.1.1
 scipy
 pillow

--- a/tests-requirements.txt
+++ b/tests-requirements.txt
@@ -2,6 +2,6 @@ matplotlib
 pip
 freeimage
 coveralls
-pytest==8.1.1
+pytest<=8.1.1
 scipy
 pillow


### PR DESCRIPTION
Based on experiments, the pytest started importing mahotas from source, not wheel. Limiting to latest working looks resolving the problem 
 