### PR TITLE
fix: numpy 2.0 compatybility (`array.max()` dtype problem)

### DIFF
--- a/mahotas/features/texture.py
+++ b/mahotas/features/texture.py
@@ -132,7 +132,7 @@ def haralick(f,
         nr_dirs = len(_3d_deltas)
     else:
         raise ValueError('mahotas.texture.haralick: Can only handle 2D and 3D images.')
-    fm1 = f.max() + 1
+    fm1 = int(f.max()) + 1
     cmat = np.empty((fm1, fm1), np.int32)
     def all_cmatrices():
         for dir in range(nr_dirs):

--- a/mahotas/tests/test_texture.py
+++ b/mahotas/tests/test_texture.py
@@ -171,6 +171,7 @@ def test_4d_image():
 def rand_haralick():
     f = 255*np.random.random((128,128))
     f = f.astype(np.uint8)
+    f[0, 0] = 255
     f = mh.features.haralick(f)
     return f.mean(0)
 def test_feature_non_zero():


### PR DESCRIPTION
I found in my tests that since numpy 2.0 the `data.max()` returns the same dtype as array data. 
So for array of type np.uint8 and max value 255 it leads to create cmat of size 0, 0.

This PR converts size to in before increasing it by 1. 