### PR TITLE
Feature/elen thresholding

### DIFF
--- a/mahotas/tests/test_thresholding.py
+++ b/mahotas/tests/test_thresholding.py
@@ -2,7 +2,7 @@
 # License: MIT
 
 import numpy as np
-from mahotas.thresholding import otsu, rc, bernsen, gbernsen
+from mahotas.thresholding import otsu, rc, bernsen, gbernsen, elen
 from mahotas.histogram import fullhistogram
 import pytest
 
@@ -114,3 +114,9 @@ def test_gbernsen():
         f = f.astype(np.uint8)
         b = gbernsen(f, np.ones((3,3), bool), 15, 145)
         assert f.shape == b.shape
+
+def test_elen_threshold():
+    img = np.array([[100, 150], [200, 50]], dtype=np.uint8)
+    t = elen(img)
+    assert isinstance(t, float)
+    assert t == 125


### PR DESCRIPTION
### Summary

This pull request adds a new global thresholding function, `elen()`, based on the method proposed by Elen & Dönmez (2024). It is implemented in `thresholding.py` and designed to align with Mahotas' thresholding interface.

---

### Changes Made

- ✅ Added `elen()` function to `thresholding.py`
- ✅ Included unit test in `test_thresholding.py`
- ✅ Updated `__all__` list to expose the new method

---

### Method Description

The method works by:
- Computing the global mean and standard deviation of the image histogram
- Defining an α-region: [mean − std, mean + std]
- Computing average intensities of α and β (peripheral) regions
- Setting the threshold as the mean of the α and β regional averages

---

### Example Usage

```python
import mahotas
t = mahotas.elen(image)
binary = (image > t)
